### PR TITLE
Add openEuler support

### DIFF
--- a/.github/workflows/openeuler.yml
+++ b/.github/workflows/openeuler.yml
@@ -1,0 +1,41 @@
+name: Build Docker images (openEuler)
+
+permissions:
+  packages: write      
+
+on:
+  pull_request:
+    paths:
+      - 'cann/Dockerfile.openeuler'
+      - 'llm/**'
+      - 'pytorch/**'
+    branches:
+      - main
+  push:
+    paths:
+      - 'cann/Dockerfile.openeuler'
+      - 'llm/**'
+      - 'pytorch/**'
+    branches:
+      - main
+
+jobs:
+  build-cann:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: |
+          docker build -t ascendai/cann:910b-openeuler2203sp2 -f ./cann/Dockerfile.openeuler .
+          docker build -t ascendai/pytorch:910b-openeuler2203sp2 -f ./pytorch/Dockerfile --build-arg BASE_IMAGE=ascendai/cann:910b-openeuler2203sp2 .
+          cd llm
+          docker build -t ascendai/llm:910b-openeuler2203sp2 -f ./Dockerfile --build-arg BASE_IMAGE=ascendai/pytorch:910b-openeuler2203sp2 .
+ 
+      - name: Push
+        if: github.event_name == 'push'
+        run: |
+          docker push ascendai/cann:910b-openeuler2203sp2
+          docker push ascendai/pytorch:910b-openeuler2203sp2
+          docker push ascendai/llm:910b-openeuler2203sp2

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,13 +1,21 @@
-name: Upload Docker images
+name: Build Docker images (Ubuntu)
 
 permissions:
   packages: write      
 
 on:
   pull_request:
+    paths:
+      - 'cann/Dockerfile.ubuntu'
+      - 'llm/**'
+      - 'pytorch/**'
     branches:
       - main
   push:
+    paths:
+      - 'cann/Dockerfile.ubuntu'
+      - 'llm/**'
+      - 'pytorch/**'
     branches:
       - main
 
@@ -21,9 +29,9 @@ jobs:
       - name: Build
         run: |
           docker build -t ascendai/cann:910b-ubuntu2004 -f ./cann/Dockerfile.ubuntu .
-          docker build -t ascendai/pytorch:910b-ubuntu2004 -f ./pytorch/Dockerfile.ubuntu .
+          docker build -t ascendai/pytorch:910b-ubuntu2004 -f ./pytorch/Dockerfile .
           cd llm
-          docker build -t ascendai/llm:910b-ubuntu2004 -f ./Dockerfile.ubuntu .
+          docker build -t ascendai/llm:910b-ubuntu2004 -f ./Dockerfile .
  
       - name: Push
         if: github.event_name == 'push'

--- a/cann/Dockerfile.openeuler
+++ b/cann/Dockerfile.openeuler
@@ -1,26 +1,24 @@
-FROM ubuntu:20.04
+FROM openeuler/openeuler:22.03-lts-sp2
 
-RUN apt update && \
-    DEBIAN_FRONTEND=noninteractive apt install -y \
+RUN yum install -y \
     git \
     wget \
     gcc \
-    g++ \
+    gcc-c++ \
     make \
-    zlib1g \
-    zlib1g-dev \
-    openssl \
-    libsqlite3-dev \
-    libssl-dev \
-    libffi-dev \
     unzip \
+    zlib-devel \
+    libffi-devel \
+    openssl-devel \
     pciutils \
     net-tools \
-    libblas-dev \
-    gfortran \
-    patchelf \
-    libblas3 && \
-    rm -rf /var/lib/apt/lists/*
+    sqlite-devel \
+    lapack-devel \
+    gcc-gfortran \
+    python3-devel \
+    util-linux \
+    patchelf && \
+    rm -rf /var/cache/yum
 
 # Install Python 3.8.11
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O ~/miniconda.sh && \

--- a/llm/Dockerfile
+++ b/llm/Dockerfile
@@ -1,4 +1,5 @@
-FROM ascendai/pytorch:910b-ubuntu2004
+ARG BASE_IMAGE=ascendai/pytorch:910b-ubuntu2004
+FROM ${BASE_IMAGE}
 
 COPY fastchat_npu.patch ./
 

--- a/llm/Dockerfile
+++ b/llm/Dockerfile
@@ -8,5 +8,5 @@ RUN git clone https://github.com/lm-sys/FastChat.git && \
     git checkout ce3311d086055d3c4d104573b64d71e67cd613b6 && \
     git apply ../fastchat_npu.patch && \
     pip install -e ".[model_worker,webui]" -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip install transformers==4.32.1 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip install accelerate==0.22.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
+    pip install --no-cache-dir transformers==4.32.1 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip install --no-cache-dir accelerate==0.22.0 -i https://pypi.tuna.tsinghua.edu.cn/simple

--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -17,7 +17,7 @@ RUN git clone https://github.com/pytorch/pytorch.git && \
     python3 setup.py develop
 
 # Replace below commands with `pip install torch_npu` after PyTorch 2.1.0 release.
-RUN git clone https://gitee.com/ascend/pytorch.git ascend-pytorch && \
+RUN git clone https://github.com/ascend/pytorch.git ascend-pytorch && \
     cd ascend-pytorch && \
     git reset 81ece7b664adc28e698044d0e9091d39a1a6dfa6 --hard && \
     pip install --no-cache-dir pyyaml wheel decorator snippy && \

--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -1,4 +1,5 @@
-FROM ascendai/cann:910b-ubuntu2004
+ARG BASE_IMAGE=ascendai/cann:910b-ubuntu2004
+FROM ${BASE_IMAGE}
 
 RUN pip install cmake ninja -i https://repo.huaweicloud.com/repository/pypi/simple
 
@@ -14,10 +15,6 @@ RUN git clone https://github.com/pytorch/pytorch.git && \
     export USE_CUDA=0 && \
     export USE_XNNPACK=0 && \
     python3 setup.py develop
-
-RUN apt update && \
-    apt install patchelf && \
-    rm -rf /var/lib/apt/lists/*
 
 # Replace below commands with `pip install torch_npu` after PyTorch 2.1.0 release.
 RUN git clone https://gitee.com/ascend/pytorch.git ascend-pytorch && \

--- a/pytorch/Dockerfile
+++ b/pytorch/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_IMAGE=ascendai/cann:910b-ubuntu2004
 FROM ${BASE_IMAGE}
 
-RUN pip install cmake ninja -i https://repo.huaweicloud.com/repository/pypi/simple
+RUN pip install --no-cache-dir cmake ninja -i https://repo.huaweicloud.com/repository/pypi/simple
 
 # Replace below commands with `pip install torch>=2.1.0` after PyTorch 2.1.0 release.
 RUN git clone https://github.com/pytorch/pytorch.git && \
@@ -11,7 +11,7 @@ RUN git clone https://github.com/pytorch/pytorch.git && \
     cp aten/src/ATen/native/CPUFallback.cpp ../ && \
     git cherry-pick --abort && \
     mv ../CPUFallback.cpp aten/src/ATen/native/CPUFallback.cpp && \
-    pip install -r ./requirements.txt -i https://repo.huaweicloud.com/repository/pypi/simple && \
+    pip install --no-cache-dir -r ./requirements.txt -i https://repo.huaweicloud.com/repository/pypi/simple && \
     export USE_CUDA=0 && \
     export USE_XNNPACK=0 && \
     python3 setup.py develop
@@ -20,9 +20,9 @@ RUN git clone https://github.com/pytorch/pytorch.git && \
 RUN git clone https://gitee.com/ascend/pytorch.git ascend-pytorch && \
     cd ascend-pytorch && \
     git reset 81ece7b664adc28e698044d0e9091d39a1a6dfa6 --hard && \
-    pip install pyyaml wheel decorator snippy && \
+    pip install --no-cache-dir pyyaml wheel decorator snippy && \
     bash ci/build.sh --python=3.8 && \
     pip3 install --upgrade dist/torch_npu-2.1.0-cp38-cp38-linux_aarch64.whl && \
     cd .. && rm -rf ascend-pytorch
 
-RUN pip install protobuf==3.20.0 attrs cython numpy decorator sympy cffi pyyaml pathlib2 psutil scipy requests absl-py
+RUN pip install --no-cache-dir protobuf==3.20.0 attrs cython numpy decorator sympy cffi pyyaml pathlib2 psutil scipy requests absl-py


### PR DESCRIPTION
This patch adds the openEuler version for ascend serious patches.

- Only cann dockerfile added separately, llm and pytorch reuse the ubuntu one.
- Add no cache for pip install command to reduce pip installation layer.
- Switch pytorch npu from gitee to github to avoid git clone failure.