### PR TITLE
refactor: add DRIVER_PATH env

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -101,7 +101,7 @@ jobs:
   pytorch:
     name: pytorch
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ success() || failure() }}
     permissions:
       packages: write
     needs:

--- a/cann/README.md
+++ b/cann/README.md
@@ -57,6 +57,6 @@ docker buildx build \
     -f cann/ubuntu/Dockerfile \
     --build-arg BASE_VERSION=22.04 \
     --build-arg CANN_CHIP=910b \
-    --build-arg CANN_VERSION=8.0.RC2 \
+    --build-arg CANN_VERSION=8.0.RC1 \
     cann/
 ```

--- a/cann/README.md
+++ b/cann/README.md
@@ -12,8 +12,9 @@ docker run \
     -v /usr/local/dcmi:/usr/local/dcmi \
     -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
     -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
-    -v /etc/ascend_install.info:/etc/ascend_install.info \
     -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -e DRIVER_PATH=/usr/local/Ascend/driver \
     -it cosdt/cann:<TAG> bash
 ```
 

--- a/cann/openeuler/Dockerfile
+++ b/cann/openeuler/Dockerfile
@@ -61,4 +61,12 @@ RUN --mount=type=cache,from=downloader,target=/tmp,source=/tmp \
     bash /tmp/cann.sh --install && \
     rm -rf /tmp/*
 
-WORKDIR /home
+# Driver path
+ENV DRIVER_PATH=/usr/local/Ascend/driver
+
+# Add the driver path to the library path
+ENV LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
+
+# Add the driver path to /etc/enironment to make sure it can take effect
+# when conntecting the container
+ENTRYPOINT ["/bin/bash", "-c", "printenv | grep DRIVER_PATH >> /etc/environment && exec \"$@\"", "--"]

--- a/cann/openeuler/Dockerfile
+++ b/cann/openeuler/Dockerfile
@@ -67,6 +67,6 @@ ENV DRIVER_PATH=/usr/local/Ascend/driver
 # Add the driver path to the library path
 ENV LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
 
-# Add the driver path to /etc/enironment to make sure it can take effect
-# when conntecting the container
+# Add the driver path to /etc/environment to make sure it can take effect
+# when connecting to the container
 ENTRYPOINT ["/bin/bash", "-c", "printenv | grep DRIVER_PATH >> /etc/environment && exec \"$@\"", "--"]

--- a/cann/openeuler/Dockerfile
+++ b/cann/openeuler/Dockerfile
@@ -61,7 +61,4 @@ RUN --mount=type=cache,from=downloader,target=/tmp,source=/tmp \
     bash /tmp/cann.sh --install && \
     rm -rf /tmp/*
 
-# Set environment variables
-ENV LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64/common/:/usr/local/Ascend/driver/lib64/driver/:${LD_LIBRARY_PATH}
-
 WORKDIR /home

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -90,8 +90,9 @@ install_cann() {
         echo "CANN Toolkit ${CANN_VERSION} installation failed."
         exit 1
     else
-        echo "source ${CANN_TOOLKIT_ENV_FILE}" >> ~/.bashrc
-        source ~/.bashrc
+        echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
+        echo "export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64/common/:/usr/local/Ascend/driver/lib64/driver/:${LD_LIBRARY_PATH}" >> /etc/profile
+        source /etc/profile
     fi
 
     # Install CANN Kernels

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 get_architecture() {
     # not case sensitive
@@ -92,7 +92,7 @@ install_cann() {
     else
         echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
         echo \
-        'if [ -n ${DRIVER_PATH} ]; then
+        'if [ -n "${DRIVER_PATH}" ]; then
             export LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
         fi' >> /etc/profile
         source /etc/profile

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -90,12 +90,11 @@ install_cann() {
         echo "CANN Toolkit ${CANN_VERSION} installation failed."
         exit 1
     else
-        # Add the driver environment variable to path
-        if [ -n ${DRIVER_PATH} ]; then
-            echo "export LD_LIBRARY_PATH=\$\{DRIVER_PATH\}/lib64/common/:\$\{DRIVER_PATH\}/lib64/driver/:\$\{LD_LIBRARY_PATH\}" >> /etc/profile
-        fi
-
         echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
+        echo \
+        'if [ -n ${DRIVER_PATH} ]; then
+            export LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
+        fi' >> /etc/profile
         source /etc/profile
     fi
 

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -34,7 +34,7 @@ download_file() {
     for ((i=1; i<=max_retries; i++)); do
         echo "Attempt $i of $max_retries..."
 
-        curl -L "${url}" --retry 5 --retry-delay 5 -sS -o "${path}"
+        curl -fsSL "${url}" -o "${path}"
 
         if [[ $? -eq 0 ]]; then
             return 0
@@ -49,7 +49,7 @@ download_file() {
 }
 
 download_cann() {
-    if [[ "${CANN_VERSION}" =~ "^8.0.RC2" ]]; then
+    if [[ ${CANN_VERSION} =~ ^8.0.RC2.alpha ]]; then
         local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C18SPC805"
     else
         local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%20${CANN_VERSION}"

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -49,7 +49,11 @@ download_file() {
 }
 
 download_cann() {
-    local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%20${CANN_VERSION}"
+    if [[ "${CANN_VERSION}" =~ "^8.0.RC2" ]]; then
+        local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/Milan-ASL/Milan-ASL%20V100R001C18SPC805"
+    else
+        local url_prefix="https://ascend-repo.obs.cn-east-2.myhuaweicloud.com/CANN/CANN%20${CANN_VERSION}"
+    fi
     local url_suffix="response-content-type=application/octet-stream"
     local toolkit_url="${url_prefix}/${TOOLKIT_FILE}?${url_suffix}"
     local kernels_url="${url_prefix}/${KERNELS_FILE}?${url_suffix}"

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -39,8 +39,8 @@ download_file() {
         if [[ $? -eq 0 ]]; then
             return 0
         else
-            echo "Download failed with error code $?. Retrying in $retry_delay seconds..."
-            sleep $retry_delay
+            echo "Download failed with error code $?. Retrying in ${retry_delay} seconds..."
+            sleep ${retry_delay}
         fi
     done
 
@@ -59,12 +59,12 @@ download_cann() {
     local kernels_url="${url_prefix}/${KERNELS_FILE}?${url_suffix}"
 
     if [ ! -f "${TOOLKIT_PATH}" ]; then
-        echo "Downloading ${TOOLKIT_FILE}"
+        echo "Downloading ${TOOLKIT_FILE} from ${toolkit_url}"
         download_file "${toolkit_url}" "${TOOLKIT_PATH}"
     fi
 
     if [ ! -f "${KERNELS_PATH}" ]; then
-        echo "Downloading ${KERNELS_FILE}"
+        echo "Downloading ${KERNELS_FILE} from ${kernels_url}"
         download_file "${kernels_url}" "${KERNELS_PATH}"
     fi
 
@@ -94,10 +94,12 @@ install_cann() {
         echo "CANN Toolkit ${CANN_VERSION} installation failed."
         exit 1
     else
-        echo \
-        'if [ -n "${DRIVER_PATH}" ]; then
+        cat >> /etc/profile <<'EOF'
+        if [ -n "${DRIVER_PATH}" ]; then
             export LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
-        fi' >> /etc/profile
+        fi
+EOF
+
         echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
         source ${CANN_TOOLKIT_ENV_FILE}
     fi

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -90,11 +90,12 @@ install_cann() {
         echo "CANN Toolkit ${CANN_VERSION} installation failed."
         exit 1
     else
-        echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
         echo \
         'if [ -n "${DRIVER_PATH}" ]; then
             export LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
         fi' >> /etc/profile
+        echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
+        source ${CANN_TOOLKIT_ENV_FILE}
     fi
 
     # Install CANN Kernels

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -91,7 +91,7 @@ install_cann() {
         exit 1
     else
         echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
-        echo "export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64/common/:/usr/local/Ascend/driver/lib64/driver/:${LD_LIBRARY_PATH}" >> /etc/profile
+        echo "export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64/common/:/usr/local/Ascend/driver/lib64/driver/:\$\{LD_LIBRARY_PATH\}" >> /etc/profile
         source /etc/profile
     fi
 

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -95,7 +95,6 @@ install_cann() {
         'if [ -n "${DRIVER_PATH}" ]; then
             export LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
         fi' >> /etc/profile
-        source /etc/profile
     fi
 
     # Install CANN Kernels

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -90,8 +90,12 @@ install_cann() {
         echo "CANN Toolkit ${CANN_VERSION} installation failed."
         exit 1
     else
+        # Add the driver environment variable to path
+        if [ -n ${DRIVER_PATH} ]; then
+            echo "export LD_LIBRARY_PATH=\$\{DRIVER_PATH\}/lib64/common/:\$\{DRIVER_PATH\}/lib64/driver/:\$\{LD_LIBRARY_PATH\}" >> /etc/profile
+        fi
+
         echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
-        echo "export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64/common/:/usr/local/Ascend/driver/lib64/driver/:\$\{LD_LIBRARY_PATH\}" >> /etc/profile
         source /etc/profile
     fi
 

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 get_architecture() {
     # not case sensitive

--- a/cann/ubuntu/Dockerfile
+++ b/cann/ubuntu/Dockerfile
@@ -78,7 +78,4 @@ RUN --mount=type=cache,from=downloader,target=/tmp,source=/tmp \
     bash /tmp/cann.sh --install && \
     rm -rf /tmp/*
 
-# Set environment variables
-ENV LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64/common/:/usr/local/Ascend/driver/lib64/driver/:${LD_LIBRARY_PATH}
-
 WORKDIR /home

--- a/cann/ubuntu/Dockerfile
+++ b/cann/ubuntu/Dockerfile
@@ -84,6 +84,6 @@ ENV DRIVER_PATH=/usr/local/Ascend/driver
 # Add the driver path to the library path
 ENV LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
 
-# Add the driver path to /etc/enironment to make sure it can take effect
-# when conntecting the container
+# Add the driver path to /etc/environment to make sure it can take effect
+# when connecting to the container
 ENTRYPOINT ["/bin/bash", "-c", "printenv | grep DRIVER_PATH >> /etc/environment && exec \"$@\"", "--"]

--- a/cann/ubuntu/Dockerfile
+++ b/cann/ubuntu/Dockerfile
@@ -78,4 +78,9 @@ RUN --mount=type=cache,from=downloader,target=/tmp,source=/tmp \
     bash /tmp/cann.sh --install && \
     rm -rf /tmp/*
 
+# Driver environment varibale
+ENV DRIVER_PATH=/usr/local/Ascend/driver
+
+ENV LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
+
 WORKDIR /home

--- a/cann/ubuntu/Dockerfile
+++ b/cann/ubuntu/Dockerfile
@@ -78,9 +78,12 @@ RUN --mount=type=cache,from=downloader,target=/tmp,source=/tmp \
     bash /tmp/cann.sh --install && \
     rm -rf /tmp/*
 
-# Driver environment varibale
+# Driver path
 ENV DRIVER_PATH=/usr/local/Ascend/driver
 
+# Add the driver path to the library path
 ENV LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
 
-WORKDIR /home
+# Add the driver path to /etc/enironment to make sure it can take effect
+# when conntecting the container
+ENTRYPOINT ["/bin/bash", "-c", "printenv | grep DRIVER_PATH >> /etc/environment && exec \"$@\"", "--"]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -66,7 +66,7 @@ target "cann-all" {
       }
     ]
     cann_chip = ["310p", "910b"]
-    cann_version = ["7.0.1", "8.0.RC1"]
+    cann_version = ["7.0.1", "8.0.RC2.alpha002"]
   }
   args = {
     BASE_VERSION = "${os.version}"
@@ -88,21 +88,21 @@ target "cann-prefer" {
         os = "ubuntu"
         os_version = "22.04"
         cann_chip = "910b"
-        cann_version = "8.0.RC1"
+        cann_version = "8.0.RC2.alpha002"
       },
       {
         tag = "8.0"
         os = "ubuntu"
         os_version = "22.04"
         cann_chip = "910b"
-        cann_version = "8.0.RC1"
+        cann_version = "8.0.RC2.alpha002"
       },
       {
         tag = "7.0"
         os = "ubuntu"
         os_version = "22.04"
         cann_chip = "910b"
-        cann_version = "7.0.0"
+        cann_version = "7.0.1"
       },
     ]
   }


### PR DESCRIPTION
1. `DRIVER_PATH ` 变量用于指定驱动路径，可通过 `docker run -e DRIVER_PATH=/usr/xxx` 在启动容器时指定
2. 在 `ENTRYPOINT` 指令中将 `docker run` 指定的路径写到 `/etc/environment` 中

原因：

1. docker run/exec 启动的是非交互式 shell，不会加载用户的 profile 等信息
2. 因此在启动时将其写入 profile，在 SSH 进入容器时就能够正确加载
