### PR TITLE
CANN: create symbolic link from python3 to python

### DIFF
--- a/.github/actions/build-and-push-docker/action.yml
+++ b/.github/actions/build-and-push-docker/action.yml
@@ -91,8 +91,8 @@ runs:
         provenance: false
         sbom: false
         set: |
-          *.cache-from=type=gha
-          *.cache-to=type=gha,mode=min
+          *.cache-from=
+          *.cache-to=
 
     - name: Export metadata
       id: export

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -90,8 +90,8 @@ install_cann() {
     check_python
 
     # Install dependencies
-    pip3 config set global.index-url https://repo.huaweicloud.com/repository/pypi/simple
-    pip3 install --no-cache-dir attrs cython numpy decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py
+    pip config set global.index-url https://repo.huaweicloud.com/repository/pypi/simple
+    pip install --no-cache-dir attrs cython numpy decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py
 
     # Download installers
     if [ ! -f "${TOOLKIT_PATH}" ] || [ ! -f "${KERNELS_PATH}" ]; then

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -72,11 +72,11 @@ download_cann() {
 }
 
 check_python() {
-    if [ ! $(command -v python) ]; then
-        if [ $(command -v python3) ]; then
+    if ! command -v python &> /dev/null; then
+        if command -v python3 &> /dev/null; then
             # Create symbolic link from python3 to python
-            ln -sf $(which python3) $(dirname $(which python3))/python
-            ln -sf $(which pip3) $(dirname $(which pip3))/pip
+            ln -sf "$(command -v python3)" "$(dirname "$(command -v python3)")/python"
+            ln -sf "$(command -v pip3)" "$(dirname "$(command -v pip3)")/pip"
             echo "Created symbolic link 'python' pointing to 'python3'."
         else
             echo "Python not installed."

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -71,7 +71,24 @@ download_cann() {
     echo "CANN ${CANN_VERSION} download successful."
 }
 
+check_python() {
+    if [ ! $(command -v python) ]; then
+        if [ $(command -v python3) ]; then
+            # Create symbolic link from python3 to python
+            ln -sf $(which python3) $(dirname $(which python3))/python
+            ln -sf $(which pip3) $(dirname $(which pip3))/pip
+            echo "Created symbolic link 'python' pointing to 'python3'."
+        else
+            echo "Python not installed."
+            exit 1
+        fi
+    fi
+}
+
 install_cann() {
+    # Check python
+    check_python
+
     # Install dependencies
     pip3 config set global.index-url https://repo.huaweicloud.com/repository/pypi/simple
     pip3 install --no-cache-dir attrs cython numpy decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -65,8 +65,8 @@ target "cann-all" {
         version = "22.03"
       }
     ]
-    cann_chip = ["310p", "910b"]
-    cann_version = ["7.0.1", "8.0.RC2.alpha002"]
+    cann_chip = ["310p", "910", "910b"]
+    cann_version = ["7.0.1", "8.0.RC1", "8.0.RC2.alpha002"]
   }
   args = {
     BASE_VERSION = "${os.version}"


### PR DESCRIPTION
- 使用操作系统包管理器安装 python 后，创建 python3 的软链接
