### PR TITLE
CANN: fix env

### DIFF
--- a/cann/openeuler/Dockerfile
+++ b/cann/openeuler/Dockerfile
@@ -46,7 +46,8 @@ RUN yum install -y \
         pciutils \
         net-tools \
         sqlite-devel \
-        lapack-devel gcc-gfortran \
+        lapack-devel \
+        gcc-gfortran \
         python3-devel \
         python3-pip \
         wget \

--- a/cann/scripts/cann.sh
+++ b/cann/scripts/cann.sh
@@ -111,12 +111,15 @@ install_cann() {
         echo "CANN Toolkit ${CANN_VERSION} installation failed."
         exit 1
     else
-        cat >> /etc/profile <<'EOF'
+        DRIVER_PATH_ENV=$(cat <<'EOF'
 if [ -n "${DRIVER_PATH}" ]; then
     export LD_LIBRARY_PATH=${DRIVER_PATH}/lib64/common/:${DRIVER_PATH}/lib64/driver/:${LD_LIBRARY_PATH}
 fi
-EOF
+EOF)
+        echo "${DRIVER_PATH_ENV}" >> /etc/profile
+        echo "${DRIVER_PATH_ENV}" >> ~/.bashrc
         echo "source ${CANN_TOOLKIT_ENV_FILE}" >> /etc/profile
+        echo "source ${CANN_TOOLKIT_ENV_FILE}" >> ~/.bashrc
         source ${CANN_TOOLKIT_ENV_FILE}
     fi
 

--- a/cann/ubuntu/Dockerfile
+++ b/cann/ubuntu/Dockerfile
@@ -65,7 +65,6 @@ RUN apt-get update \
         python3 \
         python3-pip \
         python3-dev \
-        vim \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /var/tmp/* \


### PR DESCRIPTION
part of https://github.com/cosdt/pytorch/issues/41

- cann toolkit 环境变量同时写入 /etc/profile 和 /root/.bashrc，前者保证所有用户在登录时（比如 ssh 进入容器）能够自动加载变量，后者保证在进入 bash 终端能自动加载

